### PR TITLE
recognize returning at end of eval

### DIFF
--- a/ink_test.go
+++ b/ink_test.go
@@ -267,6 +267,7 @@ func TestSamples(t *testing.T) {
 		"choice-condition",
 		"func-abs",
 		"func-text-content",
+		"func-return-eval",
 		"global",
 		"if-else",
 		"math",

--- a/testdata/func-return-eval.ink
+++ b/testdata/func-return-eval.ink
@@ -1,0 +1,12 @@
+/*
+The function `get` ends with a `/ev` statement.
+We need to check for this as a possible return point.
+*/
+LIST Inventory = (none), cane, knife
+
+Have {Inventory}
+~ get(cane)
+Have {Inventory}
+
+=== function get(x)
+    ~ Inventory += x

--- a/testdata/func-return-eval.ink.json
+++ b/testdata/func-return-eval.ink.json
@@ -1,0 +1,83 @@
+{
+  "inkVersion": 21,
+  "root": [
+    [
+      "^Have ",
+      "ev",
+      {
+        "VAR?": "Inventory"
+      },
+      "out",
+      "/ev",
+      "\n",
+      "ev",
+      {
+        "VAR?": "cane"
+      },
+      {
+        "f()": "get"
+      },
+      "pop",
+      "/ev",
+      "\n",
+      "^Have ",
+      "ev",
+      {
+        "VAR?": "Inventory"
+      },
+      "out",
+      "/ev",
+      "\n",
+      [
+        "done",
+        {
+          "#n": "g-0"
+        }
+      ],
+      null
+    ],
+    "done",
+    {
+      "get": [
+        {
+          "temp=": "x"
+        },
+        "ev",
+        {
+          "VAR?": "Inventory"
+        },
+        {
+          "VAR?": "x"
+        },
+        "+",
+        {
+          "VAR=": "Inventory",
+          "re": true
+        },
+        "/ev",
+        null
+      ],
+      "global decl": [
+        "ev",
+        {
+          "list": {
+            "Inventory.none": 1
+          }
+        },
+        {
+          "VAR=": "Inventory"
+        },
+        "/ev",
+        "end",
+        null
+      ]
+    }
+  ],
+  "listDefs": {
+    "Inventory": {
+      "none": 1,
+      "cane": 2,
+      "knife": 3
+    }
+  }
+}

--- a/testdata/func-return-eval.ink.txt
+++ b/testdata/func-return-eval.ink.txt
@@ -1,0 +1,2 @@
+Have none
+Have none, cane


### PR DESCRIPTION
Adds a test for a function that ends with a `/ev` statement. This wasn't being detected properly as an exit point for the function.
rename test file