### PR TITLE
support glue and improved whitespace stripping

### DIFF
--- a/glue/glue.go
+++ b/glue/glue.go
@@ -1,0 +1,238 @@
+package glue
+
+type RuneWriter interface {
+	WriteRune(rune) (n int, err error)
+}
+
+type StringWriter interface {
+	WriteString(string) (n int, err error)
+}
+
+type RuneStringWriter interface {
+	RuneWriter
+	StringWriter
+	WriteEnd() (n int, err error)
+}
+
+type writer struct {
+	RuneWriter
+	state stateFn
+}
+
+func NewWriter(b RuneWriter) RuneStringWriter {
+	return &writer{b, stateBeginText}
+}
+
+func (w *writer) WriteEnd() (n int, err error) {
+	return w.WriteRune(StreamEnd)
+}
+
+func (w *writer) WriteString(s string) (n int, err error) {
+	return writeRunes(w, []rune(s)...)
+}
+
+func (w *writer) WriteRune(r rune) (n int, err error) {
+	w.state, n, err = w.state(w.RuneWriter, r)
+	return
+}
+
+const (
+	// Use U+2060 WORD JOINER to prevent line breaks at this point. Will need
+	// the output handler to look for this and combine lines, but seems like
+	// this should be a useful way to detect glue.
+	Glue = '\u2060'
+
+	// Use control codes to mark the start & end of functions.
+	// Using "Shift Out" and "Shift In" somewhat arbitrarily since they're
+	// paired, but just need something that would not be valid in the output.
+	FuncStart = '\u000e'
+	FuncEnd   = '\u000f'
+
+	// Use NUL byte to mark the end of a stream of text. This is used by
+	// WriteEnd to put a '\n' if needed after a block of text. This mainly
+	// resets the state before presenting something like a choice that would
+	// force a new line.
+	StreamEnd = '\u0000'
+)
+
+type stateFn func(b RuneWriter, r rune) (stateFn, int, error)
+
+func stateBeginText(b RuneWriter, r rune) (stateFn, int, error) {
+	switch r {
+	case '\n', ' ':
+		return stateBeginText, 0, nil
+	case FuncStart:
+		return stateFuncStartBeginText, 0, nil
+	case FuncEnd, StreamEnd:
+		return stateBeginText, 0, nil
+	case Glue:
+		return stateGlue, 0, nil
+	default:
+		n, err := b.WriteRune(r)
+		return stateInWord, n, err
+	}
+}
+
+func stateFuncStartBeginText(b RuneWriter, r rune) (stateFn, int, error) {
+	switch r {
+	case '\n', ' ':
+		return stateBeginText, 0, nil
+	case FuncStart:
+		return stateFuncStartBeginText, 0, nil
+	case FuncEnd, StreamEnd:
+		return stateBeginText, 0, nil
+	case Glue:
+		return stateGlue, 0, nil
+	default:
+		return next(stateInWord, b, r)
+	}
+}
+
+func stateBeginLine(b RuneWriter, r rune) (stateFn, int, error) {
+	switch r {
+	case '\n', ' ':
+		return stateBeginLine, 0, nil
+	case FuncStart:
+		return stateFuncStartBeginLine, 0, nil
+	case FuncEnd:
+		return stateInWord, 0, nil
+	case Glue:
+		return stateGlue, 0, nil
+	case StreamEnd:
+		return next(stateBeginText, b, '\n')
+	default:
+		return next(stateInWord, b, '\n', r)
+	}
+}
+
+func stateFuncStartBeginLine(b RuneWriter, r rune) (stateFn, int, error) {
+	switch r {
+	case '\n', ' ':
+		return stateFuncStartBeginLine, 0, nil
+	case FuncStart:
+		return stateFuncStartBeginLine, 0, nil
+	case FuncEnd:
+		return stateBeginLine, 0, nil
+	case Glue:
+		return stateGlue, 0, nil
+	case StreamEnd:
+		return next(stateBeginText, b, '\n')
+	default:
+		return next(stateInWord, b, '\n', r)
+	}
+}
+
+func stateFuncStartInWord(b RuneWriter, r rune) (stateFn, int, error) {
+	switch r {
+	case '\n':
+		return stateInWord, 0, nil
+	case ' ':
+		return stateSpaces, 0, nil
+	case FuncStart:
+		return stateFuncStartInWord, 0, nil
+	case FuncEnd:
+		return stateInWord, 0, nil
+	case Glue:
+		return stateGlue, 0, nil
+	case StreamEnd:
+		return next(stateBeginText, b, '\n')
+	default:
+		return next(stateInWord, b, r)
+	}
+}
+
+func stateFuncStartSpace(b RuneWriter, r rune) (stateFn, int, error) {
+	switch r {
+	case '\n', ' ':
+		return stateFuncStartSpace, 0, nil
+	case FuncStart:
+		return stateFuncStartSpace, 0, nil
+	case FuncEnd:
+		return stateSpaces, 0, nil
+	case Glue:
+		return stateGlueSpace, 0, nil
+	case StreamEnd:
+		return next(stateBeginText, b, '\n')
+	default:
+		return next(stateInWord, b, ' ', r)
+	}
+}
+
+func stateGlue(b RuneWriter, r rune) (stateFn, int, error) {
+	switch r {
+	case ' ':
+		return stateGlueSpace, 0, nil
+	case '\n', Glue, FuncStart, FuncEnd:
+		return stateGlue, 0, nil
+	case StreamEnd:
+		return next(stateBeginText, b, '\n')
+	default:
+		return next(stateInWord, b, r)
+	}
+}
+
+func stateGlueSpace(b RuneWriter, r rune) (stateFn, int, error) {
+	switch r {
+	case ' ', '\n', Glue, FuncStart, FuncEnd:
+		return stateGlueSpace, 0, nil
+	case StreamEnd:
+		return next(stateBeginText, b, '\n')
+	default:
+		return next(stateInWord, b, ' ', r)
+	}
+}
+
+func stateInWord(b RuneWriter, r rune) (stateFn, int, error) {
+	switch r {
+	case ' ':
+		return stateSpaces, 0, nil
+	case '\n':
+		return stateBeginLine, 0, nil
+	case FuncStart:
+		return stateFuncStartInWord, 0, nil
+	case FuncEnd:
+		return stateInWord, 0, nil
+	case Glue:
+		return stateGlue, 0, nil
+	case StreamEnd:
+		return next(stateBeginText, b, '\n')
+	default:
+		return next(stateInWord, b, r)
+	}
+}
+
+func stateSpaces(b RuneWriter, r rune) (stateFn, int, error) {
+	switch r {
+	case ' ':
+		return stateSpaces, 0, nil
+	case '\n':
+		return stateBeginLine, 0, nil
+	case FuncStart:
+		return stateFuncStartSpace, 0, nil
+	case FuncEnd:
+		return stateSpaces, 0, nil
+	case Glue:
+		return stateGlueSpace, 0, nil
+	case StreamEnd:
+		return next(stateBeginText, b, '\n')
+	default:
+		return next(stateInWord, b, ' ', r)
+	}
+}
+
+func next(state stateFn, b RuneWriter, runes ...rune) (_ stateFn, n int, err error) {
+	n, err = writeRunes(b, runes...)
+	return state, n, err
+}
+
+func writeRunes(b RuneWriter, runes ...rune) (n int, err error) {
+	var m int
+	for _, r := range runes {
+		m, err = b.WriteRune(r)
+		n += m
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/glue/glue_test.go
+++ b/glue/glue_test.go
@@ -1,0 +1,111 @@
+package glue_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mgood/gouache/glue"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGlue(t *testing.T) {
+	var b strings.Builder
+	w := glue.NewWriter(&b)
+	w.WriteString("one\ntwo\n")
+	w.WriteEnd()
+	assert.Equal(t, "one\ntwo\n", b.String())
+}
+
+func TestGlueInFunc(t *testing.T) {
+	var b strings.Builder
+	w := glue.NewWriter(&b)
+	w.WriteString("before ")
+	w.WriteRune(glue.FuncStart)
+	w.WriteString("\n\nin-func\n\n")
+	w.WriteRune(glue.FuncEnd)
+	w.WriteString(" after")
+	w.WriteEnd()
+	assert.Equal(t, "before in-func after\n", b.String())
+}
+
+func TestSpaceAfterFuncBeginText(t *testing.T) {
+	var b strings.Builder
+	w := glue.NewWriter(&b)
+	w.WriteRune(glue.FuncStart)
+	w.WriteString("\n\n")
+	w.WriteRune(glue.FuncEnd)
+	w.WriteString(" after")
+	w.WriteEnd()
+	assert.Equal(t, "after\n", b.String())
+}
+
+func TestSpaceAfterFuncLine(t *testing.T) {
+	var b strings.Builder
+	w := glue.NewWriter(&b)
+	w.WriteString("before\n")
+	w.WriteRune(glue.FuncStart)
+	w.WriteString("\n\n")
+	w.WriteRune(glue.FuncEnd)
+	w.WriteString(" after")
+	w.WriteEnd()
+	assert.Equal(t, "before\nafter\n", b.String())
+}
+
+func TestSpaceAfterFuncLine2(t *testing.T) {
+	var b strings.Builder
+	w := glue.NewWriter(&b)
+	w.WriteString("before\n")
+	w.WriteRune(glue.FuncStart)
+	w.WriteRune(glue.FuncEnd)
+	w.WriteString(" after")
+	w.WriteEnd()
+	assert.Equal(t, "before\nafter\n", b.String())
+}
+
+func TestSpaceBeforeFuncOutput(t *testing.T) {
+	var b strings.Builder
+	w := glue.NewWriter(&b)
+	w.WriteString("before ")
+	w.WriteRune(glue.FuncStart)
+	w.WriteString("inside\n")
+	w.WriteRune(glue.FuncEnd)
+	w.WriteString(" after")
+	w.WriteEnd()
+	assert.Equal(t, "before inside after\n", b.String())
+}
+
+func TestSpaceBeforeFuncOutput2(t *testing.T) {
+	var b strings.Builder
+	w := glue.NewWriter(&b)
+	w.WriteString("before ")
+	w.WriteRune(glue.FuncStart)
+	w.WriteString("inside\n")
+	w.WriteRune(glue.FuncEnd)
+	w.WriteString(", after")
+	w.WriteEnd()
+	assert.Equal(t, "before inside, after\n", b.String())
+}
+
+func TestNewlineAfterFunc(t *testing.T) {
+	var b strings.Builder
+	w := glue.NewWriter(&b)
+	w.WriteString("before\n")
+	w.WriteRune(glue.FuncStart)
+	w.WriteString("\ninside\n")
+	w.WriteRune(glue.FuncEnd)
+	w.WriteString("\nafter")
+	w.WriteEnd()
+	assert.Equal(t, "before\ninside\nafter\n", b.String())
+}
+
+func TestImplicitInlineGlue(t *testing.T) {
+	var b strings.Builder
+	w := glue.NewWriter(&b)
+	w.WriteString("before ")
+	w.WriteRune(glue.FuncStart)
+	w.WriteString("\n")
+	w.WriteRune(glue.FuncEnd)
+	w.WriteString("\nafter")
+	w.WriteEnd()
+	assert.Equal(t, "before\nafter\n", b.String())
+}

--- a/ink.go
+++ b/ink.go
@@ -27,6 +27,7 @@ type Node interface{}
 
 type Text string
 type Newline struct{} // "\n"
+type Glue struct{}    // "<>"
 type Address string
 
 func (a Address) Parent() Address {

--- a/json.go
+++ b/json.go
@@ -80,6 +80,8 @@ func loadNode(n any) Node {
 			return Done{}
 		case "\n":
 			return Newline{}
+		case "<>":
+			return Glue{}
 		case "ev":
 			return BeginEval{}
 		case "/ev":

--- a/testdata/glue.ink
+++ b/testdata/glue.ink
@@ -1,0 +1,16 @@
+glue directly between<>words
+
+glue between
+<>
+lines
+
+glue newline
+<> space after line
+
+glue first line<>
+
+then newline
+
+space before glue <>
+
+ space after newline

--- a/testdata/glue.ink.json
+++ b/testdata/glue.ink.json
@@ -1,0 +1,42 @@
+{
+  "inkVersion": 21,
+  "root": [
+    [
+      "^glue directly between",
+      "<>",
+      "^words",
+      "\n",
+      "^glue between",
+      "\n",
+      "<>",
+      "\n",
+      "^lines",
+      "\n",
+      "^glue newline",
+      "\n",
+      "<>",
+      "^ space after line",
+      "\n",
+      "^glue first line",
+      "<>",
+      "\n",
+      "^then newline",
+      "\n",
+      "^space before glue ",
+      "<>",
+      "\n",
+      "^space after newline",
+      "\n",
+      [
+        "done",
+        {
+          "#n": "g-0"
+        }
+      ],
+      null
+    ],
+    "done",
+    null
+  ],
+  "listDefs": {}
+}

--- a/testdata/glue.ink.txt
+++ b/testdata/glue.ink.txt
@@ -1,0 +1,5 @@
+glue directly betweenwords
+glue betweenlines
+glue newline space after line
+glue first linethen newline
+space before glue space after newline


### PR DESCRIPTION
The `glue` package adds a stateful text buffer to handle stripping whitespaces.
Supports the special cases for trimming the extra newline that appear at the beginning & end of a function, trailing spaces, etc.
Tested agains the ink-proof tests and a few additional focused glue tests.