### PR TITLE
tunnel choices preserve stack

### DIFF
--- a/cmd/gouache/gouache.go
+++ b/cmd/gouache/gouache.go
@@ -22,7 +22,7 @@ func main() {
 	}
 	b := bufio.NewWriter(os.Stdout)
 	w := glue.NewWriter(b)
-	choices, eval := Continue(w, gouache.Init(elem, listDefs), elem)
+	choices := gouache.Continue(w, gouache.Init(elem, listDefs), elem)
 	for len(choices) > 0 {
 		w.WriteEnd()
 		b.WriteRune('\n')
@@ -34,43 +34,9 @@ func main() {
 		b.Flush()
 		var i int
 		fmt.Scanln(&i)
-		choices, eval = Continue(w, eval, choices[i-1].Dest)
+		choice := choices[i-1]
+		choices = gouache.Continue(w, choice.Eval, choice.Dest)
 	}
 	w.WriteEnd()
 	b.Flush()
-}
-
-func Continue(output glue.StringWriter, eval gouache.Evaluator, elem gouache.Element) ([]gouache.Choice, gouache.Evaluator) {
-	var choices []gouache.Choice
-	var defaultChoice *gouache.Choice
-	var s gouache.Output
-	var choice *gouache.Choice
-	write := func(o gouache.Output) {
-		output.WriteString(o.String())
-	}
-	for ; ; s, choice, elem, eval = eval.Step(elem) {
-		write(s)
-		if choice != nil {
-			if choice.IsInvisibleDefault {
-				defaultChoice = choice
-			} else {
-				choices = append(choices, *choice)
-			}
-		}
-		if elem != nil {
-			continue
-		}
-		if len(choices) == 0 && defaultChoice != nil {
-			elem = defaultChoice.Dest
-			defaultChoice = nil
-			continue
-		}
-		if len(choices) == 1 && defaultChoice != nil {
-			elem = defaultChoice.Dest
-			defaultChoice = nil
-			continue
-		}
-		break
-	}
-	return choices, eval
 }

--- a/ink.go
+++ b/ink.go
@@ -67,11 +67,9 @@ type ChoicePoint struct {
 }
 
 type Divert struct {
-	Dest             Address `json:"->"`
-	Var              bool    `json:"var"`
-	Conditional      bool    `json:"c"`
-	incTurnCount     bool
-	resetChoiceCount bool
+	Dest        Address `json:"->"`
+	Var         bool    `json:"var"`
+	Conditional bool    `json:"c"`
 }
 
 type FuncCall struct {

--- a/inkproof_test.go
+++ b/inkproof_test.go
@@ -40,7 +40,7 @@ func TestInkProofBytecode(t *testing.T) {
 			root, listDefs := load(t, filepath.Join(base, "bytecode.json"))
 			var b strings.Builder
 			w := glue.NewWriter(&b)
-			choices, eval := Continue(t, w, Init(root, listDefs), root)
+			choices := ContinueT(t, w, Init(root, listDefs), root)
 			for len(choices) > 0 {
 				w.WriteEnd()
 				b.WriteRune('\n')
@@ -48,9 +48,10 @@ func TestInkProofBytecode(t *testing.T) {
 					b.WriteString(fmt.Sprintf("%d: %s\n", i+1, choice.Label))
 				}
 				b.WriteString("?> ")
-				var choice int
-				fmt.Fscanln(input, &choice)
-				choices, eval = Continue(t, w, eval, choices[choice-1].Dest)
+				var choiceNum int
+				fmt.Fscanln(input, &choiceNum)
+				choice := choices[choiceNum-1]
+				choices = ContinueT(t, w, choice.Eval, choice.Dest)
 			}
 			w.WriteEnd()
 			actual := b.String()
@@ -59,7 +60,7 @@ func TestInkProofBytecode(t *testing.T) {
 	}
 }
 
-func openfile(t *testing.T, fn string) io.Reader {
+func openfile(t TBMinimal, fn string) io.Reader {
 	t.Helper()
 	b, err := os.Open(fn)
 	require.NoError(t, err)
@@ -105,11 +106,8 @@ func TestInkProofInk(t *testing.T) {
 				"I063": "divert weave points",
 				"I065": "tunnel choice stack",
 				"I066": "tunnel self timeout",
-				"I077": "variable assigned in choice",
 				"I079": "visit counts",
-				"I083": "variable assigned in choice",
 				"I089": "visit counts",
-				"I093": "visit counts",
 				"I098": "knot & thread interaction",
 				"I099": "tags",
 				"I100": "tags",
@@ -137,7 +135,7 @@ func TestInkProofInk(t *testing.T) {
 				t.Logf("%q", s)
 				return w.WriteString(s)
 			})
-			choices, eval := Continue(t, write, Init(root, listDefs), root)
+			choices := ContinueT(t, write, Init(root, listDefs), root)
 			for len(choices) > 0 {
 				w.WriteEnd()
 				b.WriteRune('\n')
@@ -146,9 +144,10 @@ func TestInkProofInk(t *testing.T) {
 				}
 				w.WriteEnd()
 				b.WriteString("?> ")
-				var choice int
-				fmt.Fscanln(input, &choice)
-				choices, eval = Continue(t, write, eval, choices[choice-1].Dest)
+				var choiceNum int
+				fmt.Fscanln(input, &choiceNum)
+				choice := choices[choiceNum-1]
+				choices = ContinueT(t, write, choice.Eval, choice.Dest)
 			}
 			w.WriteEnd()
 			actual := b.String()

--- a/ops.go
+++ b/ops.go
@@ -18,12 +18,6 @@ func (n Divert) GetDest(el Element, stack *CallFrame) (Element, *CallFrame) {
 			return el.Next(), stack
 		}
 	}
-	if n.incTurnCount {
-		stack = stack.IncTurnCount()
-	}
-	if n.resetChoiceCount {
-		stack = stack.ResetChoiceCount()
-	}
 	dest := el.Find(addr)
 	if dest == nil {
 		panic(fmt.Errorf("divert target %q not found", n.Dest))


### PR DESCRIPTION
Choices inside a tunnel should return to that stack frame when followed.
This passes ink-proof I077, I083, and I093.

Right now it returns to the stack as it was when the choice was created. This may need more testing for things like if variables were changed between the time the choice was created and following the choice.