### PR TITLE
report errors reading choice

### DIFF
--- a/cmd/gouache/gouache.go
+++ b/cmd/gouache/gouache.go
@@ -33,7 +33,9 @@ func main() {
 		b.WriteString("?> ")
 		b.Flush()
 		var i int
-		fmt.Scanln(&i)
+		if _, err := fmt.Scanln(&i); err != nil {
+			log.Fatalf("unable to read input: %s", err)
+		}
 		choice := choices[i-1]
 		choices = gouache.Continue(w, choice.Eval, choice.Dest)
 	}

--- a/inkproof_test.go
+++ b/inkproof_test.go
@@ -143,7 +143,9 @@ func TestInkProofInk(t *testing.T) {
 				w.WriteEnd()
 				b.WriteString("?> ")
 				var choiceNum int
-				fmt.Fscanln(input, &choiceNum)
+				if _, err := fmt.Fscanln(input, &choiceNum); err != nil {
+					t.Fatalf("unable to read choice input: %s", err)
+				}
 				choice := choices[choiceNum-1]
 				choices = ContinueT(t, write, choice.Eval, choice.Dest)
 			}


### PR DESCRIPTION
In particular for ink-proof testing this happens when we run out of inputs while expecting another choice. Make this result a bit more readable instead of triggering an index error.