### PR TITLE
var ref to self

### DIFF
--- a/ink.go
+++ b/ink.go
@@ -431,7 +431,8 @@ func shuffle(container string, elements, visitIndex int) int {
 }
 
 type SetTemp struct {
-	Name string `json:"temp="`
+	Name     string `json:"temp="`
+	Reassign bool   `json:"re"`
 }
 
 type SetVar struct {

--- a/inkproof_test.go
+++ b/inkproof_test.go
@@ -117,7 +117,6 @@ func TestInkProofInk(t *testing.T) {
 				"I122": "eval stack",
 				"I128": "visit counts",
 				"I130": "knots & thread interaction",
-				"I131": "knots",
 			}
 			if reason, ok := skipReasons[name]; ok {
 				t.Skipf("%s is a known failure: %s", name, reason)

--- a/json.go
+++ b/json.go
@@ -224,9 +224,13 @@ func loadNode(n any) Node {
 			}
 		}
 		if v, ok := n["temp="]; ok {
-			return SetTemp{
+			r := SetTemp{
 				Name: v.(string),
 			}
+			if v, ok := n["re"]; ok {
+				r.Reassign = v.(bool)
+			}
+			return r
 		}
 		if v, ok := n["VAR="]; ok {
 			r := SetVar{

--- a/ops.go
+++ b/ops.go
@@ -50,7 +50,8 @@ func (n SetVar) Apply(stack *CallFrame) *CallFrame {
 
 func (n SetTemp) Apply(stack *CallFrame) *CallFrame {
 	val, stack := stack.PopVal()
-	// TODO use "re" reassign flag to check that it's already
-	// been set?
-	return stack.WithLocal(n.Name, val)
+	if n.Reassign {
+		return stack.WithLocal(n.Name, val)
+	}
+	return stack.DeclareLocal(n.Name, val)
 }

--- a/stack.go
+++ b/stack.go
@@ -325,6 +325,20 @@ func (f *CallFrame) setRef(ref VarRef, v Value) *CallFrame {
 	return &r
 }
 
+func (f *CallFrame) DeclareLocal(name string, value Value) *CallFrame {
+	if _, ok := f.locals.Get(name); ok {
+		if r, ok := value.(VarRef); ok {
+			// we're trying to redeclare a reference to a variable with the same name
+			// in the same frame, so just return the stack unmodified since we just
+			// need to keep the existing value
+			if r.Name == name && r.ContentIndex == f.callDepth+1 {
+				return f
+			}
+		}
+	}
+	return f.withLocals(f.locals.With(name, value))
+}
+
 func (f *CallFrame) WithLocal(name string, value Value) *CallFrame {
 	v, ok := f.locals.Get(name)
 	if ok {


### PR DESCRIPTION
Fixes ink-proof I131
Handles a knot containing a `ref` to a temp var with the same name. Since they're in the same frame, this caused an infinite loop trying to resolve a ref to itself.