### PR TITLE
more visit count fixes

### DIFF
--- a/container.go
+++ b/container.go
@@ -118,21 +118,10 @@ func (c *Container) Find(name Address) (Element, []VisitAddr) {
 
 func (c *Container) find(key string) (Element, []VisitAddr) {
 	if index, err := strconv.Atoi(key); err == nil {
-		if child := c.at(index); child != nil {
-			addr, _ := child.Address()
-			return *child, []VisitAddr{{
-				Addr:       addr,
-				Flags:      c.Flags,
-				EntryIndex: index,
-			}}
-		}
-		return nil, nil
+		return c.atNoFlatten(index).Flatten()
 	}
 	if child := c.findContainer(key); child != nil {
-		return child.First(), []VisitAddr{{
-			Addr:  child.Address(),
-			Flags: child.Flags,
-		}}
+		return child.atNoFlatten(0).Flatten()
 	}
 	return nil, nil
 }

--- a/inkproof_test.go
+++ b/inkproof_test.go
@@ -92,11 +92,7 @@ func TestInkProofInk(t *testing.T) {
 			"I098": "knot & thread interaction",
 			"I099": "tags",
 			"I100": "tags",
-			"I101": "threads",
 			"I104": "thread newline?",
-			"I108": "tunnels",
-			"I111": "sequence",
-			"I122": "eval stack",
 			"I128": "visit counts",
 			"I130": "knots & thread interaction",
 		}[name]


### PR DESCRIPTION
Addresses an issue with visit counts when descending into child containers.
Ensures that Find() returns all the containers we visited to get to the leaf element.
Fixes ink-proof I101, I108, I111, I122.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #20 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #19 
<!-- GitButler Footer Boundary Bottom -->

